### PR TITLE
Run commands programmatically, instead of using `&&` operator

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var exec = require('child_process').exec;
+var execSeries = require('exec-series');
 var Download = require('download');
 var rm = require('rimraf');
 var tempfile = require('tempfile');
@@ -64,7 +64,7 @@ BinBuild.prototype.cmd = function (str) {
 BinBuild.prototype.run = function (cb) {
 	cb = cb || function () {};
 
-	var str = this.cmd().join(' && ');
+	var commands = this.cmd();
 	var tmp = tempfile();
 	var download = new Download({
 		strip: this.opts.strip,
@@ -81,7 +81,7 @@ BinBuild.prototype.run = function (cb) {
 			return;
 		}
 
-		exec(str, { cwd: tmp }, function (err) {
+		execSeries(commands, { cwd: tmp }, function (err) {
 			if (err) {
 				cb(err);
 				return;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   ],
   "dependencies": {
     "download": "^3.1.0",
+    "exec-series": "^1.0.0",
     "rimraf": "^2.2.6",
     "tempfile": "^1.0.0"
   },

--- a/test.js
+++ b/test.js
@@ -30,7 +30,7 @@ test('add commands to run', function (t) {
 	t.assert(build._cmd[1] === 'make install');
 });
 
-test('should download and build source', function (t) {
+test('download and build source', function (t) {
 	t.plan(2);
 
 	var tmp = path.join(__dirname, 'tmp');
@@ -40,7 +40,7 @@ test('should download and build source', function (t) {
 	].join(' ');
 
 	var build = new BinBuild()
-		.src('http://www.lcdf.org/gifsicle/gifsicle-1.84.tar.gz')
+		.src('http://www.lcdf.org/gifsicle/gifsicle-1.86.tar.gz')
 		.cmd('autoreconf -ivf')
 		.cmd(cmd)
 		.cmd('make install');
@@ -51,5 +51,20 @@ test('should download and build source', function (t) {
 		fs.exists(path.join(tmp, 'gifsicle'), function (exists) {
 			t.assert(exists);
 		});
+	});
+});
+
+test('pass the command error to the callback', function (t) {
+	t.plan(1);
+
+	var build = new BinBuild()
+		.src('http://www.lcdf.org/gifsicle/gifsicle-1.86.tar.gz')
+		.cmd('autoreconf -ivf')
+		.cmd('unknown-command')
+		.cmd('./configure')
+		.cmd('make install');
+
+	build.run(function (err) {
+		t.assert(err);
 	});
 });


### PR DESCRIPTION
Because Windows [PowerShell](http://microsoft.com/powershell) doesn’t support `&&` operator.

http://stackoverflow.com/questions/563600/can-i-get-to-work-in-powershell/573295#573295
