### PR TITLE
Bump dependencies and require Node.js 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - '10'
   - '8'
   - '6'
-  - '4'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/kevva"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "test": "xo && ava"
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "decompress": "^4.0.0",
-    "download": "^6.2.2",
+    "download": "^7.0.0",
     "execa": "^0.7.0",
     "p-map-series": "^1.0.0",
     "tempfile": "^2.0.0"


### PR DESCRIPTION
Bump download dependency in order to address vulnerability found in the tunnel-agent package downstream. See https://nodesecurity.io/advisories/598

Unfortunately, the `download` package decided to drop support for Node 4 as well. Considering the state of where we are in the evolution of Node, we might as well drop it here too and enable support for Node 10.

I also bumped the minor version of the package.