### PR TITLE
Update dependent module 'download' to more than 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: node_js
 node_js:
   - '8'
   - '6'
-  - '4'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bin-build",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Easily build binaries",
   "license": "MIT",
   "repository": "kevva/bin-build",
@@ -10,7 +10,7 @@
     "url": "https://github.com/kevva"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "scripts": {
     "test": "xo && ava"
@@ -25,7 +25,7 @@
   ],
   "dependencies": {
     "decompress": "^4.0.0",
-    "download": "^6.2.2",
+    "download": "^7.0.0",
     "execa": "^0.7.0",
     "p-map-series": "^1.0.0",
     "tempfile": "^2.0.0"
@@ -35,6 +35,6 @@
     "del": "^3.0.0",
     "nock": "^9.0.0",
     "path-exists": "^3.0.0",
-    "xo": "*"
+    "xo": "^0.21.0"
   }
 }


### PR DESCRIPTION
Hi! Thanks for your contribution!

When I tried 'npm install' (actually installing laravel-mix dependent libraries) under the proxy,  'MaxRedirectsError' occurred at the part accessing a resource via http instead of https. As I checked dependent library 'download' commit history, it's already merged as follows [https://github.com/kevva/download/pull/158](url), but was with major version upgrade.

I would like you to migrate this change into this module, and keep the version '3.x.x'!!

Hopefully this propose is merged and if you have anything to me, please let me know.

Thank you, 