### PR TITLE
Fix build and update dependencies to latest

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,10 @@ const execa = require('execa');
 const pMapSeries = require('p-map-series');
 const tempfile = require('tempfile');
 
-const exec = (cmd, cwd) => pMapSeries(cmd, x => execa(x, {cwd, shell: true}));
+const exec = (cmd, cwd) => pMapSeries(cmd, x => {
+	console.log(x);
+	return execa(x, {cwd, shell: true});
+});
 
 exports.directory = (dir, cmd) => {
 	if (typeof dir !== 'string') {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const execa = require('execa');
 const pMapSeries = require('p-map-series');
 const tempfile = require('tempfile');
 
-const exec = (cmd, cwd) => pMapSeries(cmd, x => execa.shell(x, {cwd}));
+const exec = (cmd, cwd) => pMapSeries(cmd, x => execa(x, {cwd, shell: true}));
 
 exports.directory = (dir, cmd) => {
 	if (typeof dir !== 'string') {
@@ -15,29 +15,31 @@ exports.directory = (dir, cmd) => {
 	return exec(cmd, dir);
 };
 
-exports.file = (file, cmd, opts) => {
-	opts = Object.assign({strip: 1}, opts);
+exports.file = async (file, cmd, options) => {
+	options = Object.assign({strip: 1}, options);
 
 	if (typeof file !== 'string') {
 		return Promise.reject(new TypeError(`Expected a \`string\`, got \`${typeof file}\``));
 	}
 
-	const tmp = tempfile();
+	const temporary = tempfile();
 
-	return decompress(file, tmp, opts).then(() => exec(cmd, tmp));
+	await decompress(file, temporary, options);
+	return exec(cmd, temporary);
 };
 
-exports.url = (url, cmd, opts) => {
-	opts = Object.assign({
+exports.url = async (url, cmd, options) => {
+	options = Object.assign({
 		extract: true,
 		strip: 1
-	}, opts);
+	}, options);
 
 	if (typeof url !== 'string') {
 		return Promise.reject(new TypeError(`Expected a \`string\`, got \`${typeof url}\``));
 	}
 
-	const tmp = tempfile();
+	const temporary = tempfile();
 
-	return download(url, tmp, opts).then(() => exec(cmd, tmp));
+	await download(url, temporary, options);
+	return exec(cmd, temporary);
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/kevva"
   },
   "engines": {
-    "node": ">=6"
+    "node": ">=7.6.0"
   },
   "scripts": {
     "test": "xo && ava"
@@ -24,17 +24,23 @@
     "make"
   ],
   "dependencies": {
-    "decompress": "^4.0.0",
-    "download": "^7.0.0",
-    "execa": "^0.7.0",
-    "p-map-series": "^1.0.0",
-    "tempfile": "^2.0.0"
+    "decompress": "^4.2.1",
+    "download": "^8.0.0",
+    "execa": "^5.0.0",
+    "p-map-series": "^2.1.0",
+    "tempfile": "^3.0.0"
   },
   "devDependencies": {
-    "ava": "*",
-    "del": "^3.0.0",
-    "nock": "^9.0.0",
-    "path-exists": "^3.0.0",
-    "xo": "*"
+    "ava": "^3.15.0",
+    "del": "^6.0.0",
+    "esm": "^3.2.25",
+    "nock": "^13.0.5",
+    "path-exists": "^4.0.0",
+    "xo": "^0.37.1"
+  },
+  "ava": {
+    "require": [
+      "esm"
+    ]
   }
 }

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ import nock from 'nock';
 import pathExists from 'path-exists';
 import tempfile from 'tempfile';
 import test from 'ava';
-import m from '.';
+import m from './index.js';
 
 test.beforeEach(t => {
 	t.context.tmp = tempfile();
@@ -39,7 +39,7 @@ test('build source from existing archive', async t => {
 });
 
 test('accepts a string', async t => {
-	await t.throws(m.directory([]), 'Expected a `string`, got `object`');
-	await t.throws(m.file([]), 'Expected a `string`, got `object`');
-	await t.throws(m.url([]), 'Expected a `string`, got `object`');
+	await t.throwsAsync(m.directory([]), {message: 'Expected a `string`, got `object`'});
+	await t.throwsAsync(m.file([]), {message: 'Expected a `string`, got `object`'});
+	await t.throwsAsync(m.url([]), {message: 'Expected a `string`, got `object`'});
 });


### PR DESCRIPTION
This PR updates all all `dependencies` and `devDependencies` to the
latest versions and updates tests so they build with the latest
`devDependencies`.

There is a breaking change to update `engines` to `>=7.6.0` due to an
`xo` lint. Exported functions are now `async` functions.

`npm test` exits with a non-zero exit code from `ava` that I'm not sure
how to address.